### PR TITLE
Add ETC and EXP symbol to eth-balance

### DIFF
--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -26,5 +26,6 @@ module.exports = {
   },
   networkIdAlterantiveChains: {
    classic: 61,
+   expanse: 2,
  },
 }

--- a/ui/app/components/eth-balance.js
+++ b/ui/app/components/eth-balance.js
@@ -16,9 +16,20 @@ function EthBalanceComponent () {
 EthBalanceComponent.prototype.render = function () {
   var props = this.props
   let { value } = props
-  const { style, width } = props
+  const { style, width, network } = props
   var needsParse = this.props.needsParse !== undefined ? this.props.needsParse : true
-  value = value ? formatBalance(value, 6, needsParse) : '...'
+  let symbol = 'ETH'
+
+  switch (network) {
+    case 2:
+      symbol = 'EXP'
+      break
+    case 61:
+      symbol = 'ETC'
+      break
+  }
+
+  value = value ? formatBalance(value, 6, needsParse, symbol) : '...'
 
   return (
 
@@ -38,26 +49,21 @@ EthBalanceComponent.prototype.render = function () {
 
 EthBalanceComponent.prototype.renderBalance = function (value) {
   var props = this.props
-  const { conversionRate, shorten, incoming, currentCurrency, network } = props
+  const { conversionRate, shorten, incoming, currentCurrency } = props
   if (value === 'None') return value
   if (value === '...') return value
   var balanceObj = generateBalanceObject(value, shorten ? 1 : 3)
   var balance
   var splitBalance = value.split(' ')
   var ethNumber = splitBalance[0]
-  var ethSuffix = splitBalance[1]
+  // var ethSuffix = splitBalance[1]
   const showFiat = 'showFiat' in props ? props.showFiat : true
+  const label = balanceObj.label
 
   if (shorten) {
     balance = balanceObj.shortBalance
   } else {
     balance = balanceObj.balance
-  }
-
-  var label = balanceObj.label
-
-  if (network == 61) {
-    label = 'ETC'
   }
 
   return (

--- a/ui/app/components/pending-tx.js
+++ b/ui/app/components/pending-tx.js
@@ -44,7 +44,7 @@ PendingTx.prototype.render = function () {
   const identity = props.identities[address] || { address: address }
   const account = props.accounts[address]
   let balance
-  
+
   if (network === 88) {
     balance = account ? account.balance : new BN(0, 16)
   } else {
@@ -124,6 +124,7 @@ PendingTx.prototype.render = function () {
                   value: balance,
                   conversionRate,
                   currentCurrency,
+                  network,
                   inline: true,
                   labelColor: '#F7861C',
                 }),
@@ -161,7 +162,7 @@ PendingTx.prototype.render = function () {
             // in the way that gas and gasLimit currently are.
             h('.row', [
               h('.cell.label', 'Amount'),
-              h(EthBalance, { value: txParams.value, currentCurrency, conversionRate }),
+              h(EthBalance, { value: txParams.value, currentCurrency, conversionRate, network }),
             ]),
 
             // Gas Limit (customizable)
@@ -214,7 +215,7 @@ PendingTx.prototype.render = function () {
             // Max Transaction Fee (calculated)
             h('.cell.row', [
               h('.cell.label', 'Max Transaction Fee'),
-              h(EthBalance, { value: txFeeBn.toString(16), currentCurrency, conversionRate }),
+              h(EthBalance, { value: txFeeBn.toString(16), currentCurrency, conversionRate, network }),
             ]),
 
             h('.cell.row', {
@@ -235,6 +236,7 @@ PendingTx.prototype.render = function () {
                   value: maxCost.toString(16),
                   currentCurrency,
                   conversionRate,
+                  network,
                   inline: true,
                   labelColor: 'black',
                   fontSize: '16px',

--- a/ui/app/components/shift-list-item.js
+++ b/ui/app/components/shift-list-item.js
@@ -67,7 +67,7 @@ function formatDate (date) {
 
 ShiftListItem.prototype.renderUtilComponents = function () {
   var props = this.props
-  const { conversionRate, currentCurrency } = props
+  const { conversionRate, currentCurrency, network } = props
 
   switch (props.response.status) {
     case 'no_deposits':
@@ -102,6 +102,7 @@ ShiftListItem.prototype.renderUtilComponents = function () {
           value: `${props.response.outgoingCoin}`,
           conversionRate,
           currentCurrency,
+          network,
           width: '55px',
           shorten: true,
           needsParse: false,

--- a/ui/app/components/transaction-list-item.js
+++ b/ui/app/components/transaction-list-item.js
@@ -22,13 +22,13 @@ function TransactionListItem () {
 TransactionListItem.prototype.render = function () {
   const { transaction, network, conversionRate, currentCurrency } = this.props
   if (transaction.key === 'shapeshift') {
-    if (network === '1') return h(ShiftListItem, transaction)
+    if (network === '1') return h(ShiftListItem, transaction, network)
   }
   var date = formatDate(transaction.time)
 
   let isLinkable = false
   const numericNet = parseInt(network)
-  isLinkable = numericNet === 1 || numericNet === 3 || numericNet === 4 || numericNet === 42 || numericNet === 61 || numericNet === 88
+  isLinkable = numericNet === 1 || numericNet === 2 || numericNet === 3 || numericNet === 4 || numericNet === 42 || numericNet === 61 || numericNet === 88
 
   var isMsg = ('msgParams' in transaction)
   var isTx = ('txParams' in transaction)
@@ -101,6 +101,7 @@ TransactionListItem.prototype.render = function () {
         value: txParams.value,
         conversionRate,
         currentCurrency,
+        network,
         width: '55px',
         shorten: true,
         showFiat: false,

--- a/ui/app/conf-tx.js
+++ b/ui/app/conf-tx.js
@@ -100,6 +100,7 @@ ConfirmTxScreen.prototype.render = function () {
         conversionRate,
         currentCurrency,
         blockGasLimit,
+        network: network,
         // Actions
         buyEth: this.buyEth.bind(this, txParams.from || props.selectedAddress),
         sendTransaction: this.sendTransaction.bind(this),

--- a/ui/app/send.js
+++ b/ui/app/send.js
@@ -133,6 +133,7 @@ SendTransactionScreen.prototype.render = function () {
               value: account && account.balance,
               conversionRate,
               currentCurrency,
+              network,
             }),
 
           ]),

--- a/ui/app/util.js
+++ b/ui/app/util.js
@@ -94,7 +94,7 @@ function parseBalance (balance) {
 
 // Takes wei hex, returns an object with three properties.
 // Its "formatted" property is what we generally use to render values.
-function formatBalance (balance, decimalsToKeep, needsParse = true) {
+function formatBalance (balance, decimalsToKeep, needsParse = true, symbol = 'ETH') {
   var parsed = needsParse ? parseBalance(balance) : balance.split('.')
   var beforeDecimal = parsed[0]
   var afterDecimal = parsed[1]
@@ -104,14 +104,14 @@ function formatBalance (balance, decimalsToKeep, needsParse = true) {
       if (afterDecimal !== '0') {
         var sigFigs = afterDecimal.match(/^0*(.{2})/) // default: grabs 2 most significant digits
         if (sigFigs) { afterDecimal = sigFigs[0] }
-        formatted = '0.' + afterDecimal + ' ETH'
+        formatted = '0.' + afterDecimal + ` ${symbol}`
       }
     } else {
-      formatted = beforeDecimal + '.' + afterDecimal.slice(0, 3) + ' ETH'
+      formatted = beforeDecimal + '.' + afterDecimal.slice(0, 3) + ` ${symbol}`
     }
   } else {
     afterDecimal += Array(decimalsToKeep).join('0')
-    formatted = beforeDecimal + '.' + afterDecimal.slice(0, decimalsToKeep) + ' ETH'
+    formatted = beforeDecimal + '.' + afterDecimal.slice(0, decimalsToKeep) + ` ${symbol}`
   }
   return formatted
 }


### PR DESCRIPTION
- Modified `EthBalanceComponent` to set the right symbol to the cryptocurrency.
- Pass `network` attribute to each `EthBalance` component. 
- Fixed Expanse `chainId`

## Demo 1

![image](https://user-images.githubusercontent.com/3322886/29546339-758996e6-86b9-11e7-8934-a152b0e9a4b4.png)

## Demo 2

![image](https://user-images.githubusercontent.com/3322886/29546381-b6a12de2-86b9-11e7-9edd-c1362e364beb.png)

## Demo 3

![image](https://user-images.githubusercontent.com/3322886/29546460-4043235c-86ba-11e7-9da2-b8607eb7dee7.png)

## Demo 4

![image](https://user-images.githubusercontent.com/3322886/29546466-4919ad70-86ba-11e7-95dc-fe7945d3fe5e.png)
