### PR TITLE
Check if the TX has params

### DIFF
--- a/ui/app/conf-tx.js
+++ b/ui/app/conf-tx.js
@@ -49,7 +49,9 @@ ConfirmTxScreen.prototype.render = function () {
   var txParams = txData.params || {}
   var isNotification = isPopupOrNotification() === 'notification'
   // Set 21000 Gas limit by default
-  txData.txParams.gas = '0x' + (new BN(21000)).toString('hex')
+  if (txData.txParams) {
+    txData.txParams.gas = '0x' + (new BN(21000)).toString('hex')
+  }
 
   log.info(`rendering a combined ${unconfTxList.length} unconf msg & txs`)
   if (unconfTxList.length === 0) return h(Loading, { isLoading: true })


### PR DESCRIPTION
Fixed when the user is creating a new transaction and the next button doesn't work.

The bug was happening because the code to set gas limit to 21000 was trying to assign it when the TX didn't have params yet.

![proof](https://user-images.githubusercontent.com/3322886/29595182-874cfb30-877b-11e7-917c-3b245de15077.gif)

Proof of the transaction: https://gastracker.io/tx/0x23cbe383ab034c901471075cd60a079068e07d7b73a106dc5c90550f458da188
